### PR TITLE
Fix Jekyll Liquid syntax errors in templating.md

### DIFF
--- a/docs/guides/templating.md
+++ b/docs/guides/templating.md
@@ -9,7 +9,7 @@ JCL provides powerful templating capabilities through its existing features, wit
 
 ## Why No Separate Template Syntax?
 
-JCL's design philosophy is to keep the language unified and composable. Instead of adding `{% if %}...{% endif %}` blocks, we leverage:
+JCL's design philosophy is to keep the language unified and composable. Instead of adding {% raw %}`{% if %}...{% endif %}`{% endraw %} blocks, we leverage:
 
 1. **String interpolation** with `${...}` - embeds any expression
 2. **Conditional expressions** - ternary, if/then/else, when
@@ -342,6 +342,7 @@ deploy_script = header + "\n" + deploy_function + "\n" + deploy_commands + "\n" 
 ## Comparison with Jinja2
 
 **Jinja2 Style:**
+{% raw %}
 ```jinja2
 {% if env == "prod" %}
 production config
@@ -353,6 +354,7 @@ dev config
 server {{ server.name }}
 {% endfor %}
 ```
+{% endraw %}
 
 **JCL Style:**
 ```jcl
@@ -446,4 +448,4 @@ JCL provides powerful templating through composition of existing features:
 - ✅ Type safety: all expressions are checked
 - ✅ Editor support: standard syntax highlighting
 
-No need for `{% %}` template syntax - JCL's unified design is more powerful and maintainable.
+No need for {% raw %}`{% %}`{% endraw %} template syntax - JCL's unified design is more powerful and maintainable.


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Pages build failure caused by Liquid syntax errors in `docs/guides/templating.md`.

## Problem

The Jekyll build was failing with:
```
Liquid Exception: Liquid syntax error (line 5): Syntax Error in tag 'if' 
- Valid syntax: if [expression] in guides/templating.md
```

## Root Cause

The file contains Jinja2 template code examples that include `{% if %}`, `{% else %}`, `{% for %}` tags. Jekyll's Liquid template engine was attempting to parse these as actual Liquid code instead of treating them as documentation examples.

## Solution

Escaped the Jinja2 code examples using Jekyll's `{% raw %}` tags at 3 locations:
- Line 12: Inline mention of `{% if %}...{% endif %}`
- Lines 345-357: Full Jinja2 code example block
- Line 451: Inline mention of `{% %}`

## Type of Change

- [x] Bug fix (fixes GitHub Pages deployment)
- [x] Documentation fix

## Testing

- [x] All existing tests pass (144 tests)
- [x] No code changes - documentation only
- [x] Verified Jekyll syntax escaping

## Checklist

- [x] Ran `cargo test` (all 144 tests pass)
- [x] No new compiler warnings
- [x] Jekyll build will succeed after merge

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)