### PR TITLE
Fix publishing workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,36 +177,37 @@ jobs:
         working-directory: bindings/nodejs
         run: npm publish --provenance --access public
 
-  publish-pypi:
-    name: Publish to PyPI
-    needs: build-release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install maturin
-        run: pip install maturin
-
-      - name: Build Python wheels
-        run: maturin build --release --manifest-path bindings/python/Cargo.toml
-
-      - name: Publish to PyPI (with trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: target/wheels/
-          skip-existing: true
+  # TODO: Re-enable when Python bindings are properly set up with maturin
+  # publish-pypi:
+  #   name: Publish to PyPI
+  #   needs: build-release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.11'
+  #
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@stable
+  #
+  #     - name: Install maturin
+  #       run: pip install maturin
+  #
+  #     - name: Build Python wheels
+  #       run: maturin build --release --manifest-path bindings/python/Cargo.toml
+  #
+  #     - name: Publish to PyPI (with trusted publishing)
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         packages-dir: target/wheels/
+  #         skip-existing: true
 
   publish-rubygems:
     name: Publish to RubyGems
@@ -244,10 +245,10 @@ jobs:
           mkdir -p ~/.gem
           cat << EOF > ~/.gem/credentials
           ---
-          :rubygems_api_key: ${RUBYGEMS_API_KEY}
+          :rubygems_api_key: ${RUBY_GEMS_API}
           EOF
           chmod 0600 ~/.gem/credentials
           gem push jcl-lang-*.gem
         env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RUBY_GEMS_API: ${{ secrets.RUBY_GEMS_API }}
 


### PR DESCRIPTION
Closes #18

## Summary
Fixes the publishing workflow issues discovered during the v1.0.0 release.

## Changes

### Fixed RubyGems Secret Name
- Changed `RUBYGEMS_API_KEY` → `RUBY_GEMS_API`
- Matches the actual secret name configured in GitHub

### Disabled PyPI Publishing
- Commented out PyPI job with TODO
- Python bindings don't have `Cargo.toml` for maturin yet
- Can be re-enabled once Python bindings are properly set up

### npm Status
- No changes needed
- Package already exists (manually published)
- Will skip on subsequent publishes

## Testing
After merge, can test with a new tag or re-run the workflow.

## What Works Now
- ✅ GitHub Releases (32 binary assets)
- ✅ crates.io publishing
- ✅ npm publishing (already published)
- ✅ RubyGems publishing (secret name fixed)
- ⏭️ PyPI publishing (disabled until bindings ready)
- ✅ Go modules (automatic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>