### PR TITLE
Fix RubyGems gem name to match trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,5 +245,5 @@ jobs:
 
       - name: Publish to RubyGems
         working-directory: bindings/ruby
-        run: gem push jcl-lang-*.gem
+        run: gem push jcl-*.gem
 

--- a/bindings/ruby/jcl.gemspec
+++ b/bindings/ruby/jcl.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |spec|
-  spec.name          = "jcl-lang"
+  spec.name          = "jcl"
   spec.version       = "1.0.0"
   spec.authors       = ["Hemmer IO"]
   spec.email         = ["info@hemmer.io"]


### PR DESCRIPTION
## Summary
Change gem name from `jcl-lang` to `jcl` to match the trusted publisher configuration on RubyGems.org.

## Problem
RubyGems trusted publisher is configured for gem name `jcl` but our gemspec uses `jcl-lang`, causing authorization failure:
```
Pushing gem to https://rubygems.org...
You are not allowed to push this gem.
```

## Changes
- `bindings/ruby/jcl.gemspec`: Changed `spec.name` from `"jcl-lang"` to `"jcl"`
- `.github/workflows/release.yml`: Updated gem push pattern from `jcl-lang-*.gem` to `jcl-*.gem`

## Testing
- Built gem locally to verify name change
- Gem will now be named `jcl-1.0.0.gem` instead of `jcl-lang-1.0.0.gem`

## Checklist
- [x] All existing tests pass
- [x] Code formatted with cargo fmt
- [x] No clippy warnings
- [x] Documentation updated (N/A)
- [x] No new compiler warnings

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)