### PR TITLE
Fix RubyGems workflow glob pattern not expanding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,11 +239,15 @@ jobs:
         run: |
           gem install bundler rake rake-compiler rb_sys
           gem build jcl.gemspec
+          ls -la *.gem
 
       - name: Configure RubyGems credentials (trusted publishing)
         uses: rubygems/configure-rubygems-credentials@v1.0.0
 
       - name: Publish to RubyGems
         working-directory: bindings/ruby
-        run: gem push jcl-*.gem
+        run: |
+          GEM_FILE=$(ls *.gem | head -1)
+          echo "Publishing $GEM_FILE"
+          gem push "$GEM_FILE"
 


### PR DESCRIPTION
## Description

Fixes #32 - RubyGems publishing workflow failing because glob pattern `jcl-*.gem` wasn't expanding.

## Problem

The RubyGems workflow was using `gem push jcl-*.gem` but the literal `*` was appearing in logs, indicating the glob pattern wasn't matching any files.

**Root cause**: The v1.0.0 tag was created before PR #30 merged, which changed the gem name from "jcl-lang" to "jcl". The workflow expects the new name but the tag points to old code.

## Changes

1. **Add debugging output**: `ls -la *.gem` after gem build to see what file was created
2. **Dynamic gem detection**: Instead of glob pattern, detect the actual gem file:
   ```yaml
   GEM_FILE=$(ls *.gem | head -1)
   echo "Publishing $GEM_FILE"
   gem push "$GEM_FILE"
   ```

## Benefits

- Works regardless of gem name changes
- Provides clear debugging output showing which file is being published
- More robust than glob pattern matching

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

This is a workflow-only change that will be tested when:
1. This PR is merged to main
2. The v1.0.0 tag is recreated to pick up all fixes (PR #30 + this PR)
3. The release workflow runs and attempts RubyGems publishing

## Checklist

- [x] Followed the issue → branch → PR workflow
- [x] Changes are focused and single-purpose
- [x] Commit message follows conventions
- [x] No code changes (workflow only, no tests needed)
- [x] Related to v1.0.0 publication effort

## Next Steps

After merging:
1. Delete the existing v1.0.0 tag and release
2. Recreate the v1.0.0 tag from the latest main
3. Monitor the release workflow to verify RubyGems publishing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>