### PR TITLE
Optimize CI workflows to run only on PR creation, not on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 


### PR DESCRIPTION
## Summary

Removes redundant workflow runs after merging PRs to main. Workflows now only run on PR events, not on push to main after merge.

This reduces CI resource usage by ~50% while maintaining the same level of code verification.

## Changes

### Updated Workflows (PR-only triggers)
- ✅ `test.yml` - Run tests only on PR creation/update
- ✅ `lint.yml` - Run clippy/fmt checks only on PR creation/update
- ✅ `build.yml` - Run multi-platform builds only on PR creation/update

### Unchanged Workflows (keep push triggers)
- ✅ `pages.yml` - Still runs on push to main (docs deployment needed)
- ✅ `release.yml` - Still runs on tags (release builds needed)

## Before vs After

### Before:
Workflows run **twice** for every merged PR:
1. ✅ On PR creation/update (verification before merge)
2. ❌ On merge to main (redundant - already verified in step 1)

### After:
Workflows run **once** per PR:
1. ✅ On PR creation/update (verification before merge)
2. ⏭️ Skip redundant run after merge

## Benefits

- **⚡ Faster merges**: No waiting for redundant CI after merge
- **💰 Reduced CI minutes**: ~50% reduction in test/lint/build workflow runs
- **🛡️ Same safety**: All code still verified before merge via PR checks
- **📦 Deployment unchanged**: Pages and releases still deploy on push to main/tags

## Workflow Trigger Comparison

| Workflow | Before | After | Notes |
|----------|--------|-------|-------|
| test.yml | `push` + `pull_request` | `pull_request` | Tests run on PR only |
| lint.yml | `push` + `pull_request` | `pull_request` | Linting on PR only |
| build.yml | `push` + `pull_request` | `pull_request` | Builds on PR only |
| pages.yml | `push` (docs) | `push` (docs) | Unchanged - deployment |
| release.yml | `tags` | `tags` | Unchanged - releases |

## Testing Plan

After this PR is merged:
1. Create a test PR → verify test/lint/build workflows run ✅
2. Merge the test PR → verify only pages workflow runs (if docs changed) ✅
3. Confirm no test/lint/build workflows run on the merge commit ✅

## Expected CI Savings

Assuming 10 PRs per week:
- **Before**: 10 PRs × 2 runs = 20 workflow runs/week
- **After**: 10 PRs × 1 run = 10 workflow runs/week
- **Savings**: 50% reduction in test/lint/build runs

## Closes

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)