### PR TITLE
Phase 3A: List comprehension index optimization

### DIFF
--- a/src/bin/jcl-bench.rs
+++ b/src/bin/jcl-bench.rs
@@ -304,6 +304,28 @@ fn run_builtin_benchmarks(args: &Args) -> Result<()> {
             result = sum * 10
         "#,
         ),
+        // Phase 3A: List Comprehension Index Optimization
+        (
+            "Phase 3A: Comprehension index (first)",
+            r#"
+            numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            first = [x * 2 for x in numbers][0]
+        "#,
+        ),
+        (
+            "Phase 3A: Comprehension index (middle)",
+            r#"
+            numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+            tenth = [x * 2 for x in numbers][9]
+        "#,
+        ),
+        (
+            "Phase 3A: Comprehension with filter",
+            r#"
+            numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+            filtered = [x for x in numbers if x > 5][2]
+        "#,
+        ),
     ];
 
     for (name, code) in benchmarks {


### PR DESCRIPTION
## Summary

Implements **Phase 3A (Evaluator-Level Optimizations)** from Issue #44, specifically the list comprehension index access optimization.

This optimization transparently improves performance when accessing specific indices of list comprehensions without requiring any code changes or API modifications.

## Changes

### Core Optimization

**Pattern Detection** (`src/evaluator.rs:201-225`):
```rust
// Detects: [expr for x in iterable][index]
if let Expression::ListComprehension { ... } = object.as_ref() {
    if target_idx >= 0 {  // Only optimize non-negative indices
        return self.evaluate_comprehension_at_index(...);
    }
}
```

**Optimized Evaluation** (`src/evaluator.rs:655-697`):
- New helper method `evaluate_comprehension_at_index`
- Iterates through source but only evaluates comprehension expr up to target index
- Handles filter conditions correctly
- Returns immediately upon reaching target (early termination)

### Performance Benefits

| Pattern | Before | After | Improvement |
|---------|--------|-------|-------------|
| `[expr for x in list][0]` | O(n) | O(1) | Constant time |
| `[expr for x in list][k]` | O(n) | O(k) | Linear in k, not n |
| Memory usage | O(n) | O(1) | No intermediate list |

**Example**:
```jcl
# Before: Evaluates all 1000 items
large = [expensive(x) for x in range(1000)]
first = large[0]

# After: Only evaluates first item (with optimization applied transparently)
first = [expensive(x) for x in range(1000)][0]  # Only evaluates expensive(0)
```

### Tests

Added 7 comprehensive tests (`src/evaluator.rs:1852-1981`):
- ✅ First element access
- ✅ Middle element access
- ✅ Filtered comprehensions
- ✅ Out of bounds error handling
- ✅ Negative indices (ensures standard evaluation used)
- ✅ Complex expressions in comprehensions
- ✅ Backward compatibility (normal comprehensions unchanged)

### Benchmarks

Added 3 Phase 3A benchmarks to `jcl-bench --builtin`:
- "Phase 3A: Comprehension index (first)"
- "Phase 3A: Comprehension index (middle)"
- "Phase 3A: Comprehension with filter"

## Design Decisions

### Why Only Non-Negative Indices?

Negative indices (`list[-1]`) require knowing the final list length, which defeats the optimization. These fall through to standard evaluation:

```jcl
[x * 2 for x in numbers][-1]  # Uses standard evaluation (needs full list)
[x * 2 for x in numbers][0]   # Uses optimization (early termination)
```

### Transparency

This optimization is **completely transparent**:
- ✅ No API changes
- ✅ No breaking changes  
- ✅ No user-visible behavior changes (except performance)
- ✅ All existing code continues to work exactly as before

## Deferred Work

Two planned optimizations were **deferred** because they depend on unimplemented language features:

1. **Slice optimization** - Blocked by lack of slice syntax (`list[0:10]`)
2. **Fusion optimization** - Blocked by lack of nested comprehensions

These will be implemented after **Issue #46** adds the missing language features.

## Testing

- ✅ All 177 tests passing (144 unit + 21 CLI + 9 integration + 3 doc)
- ✅ Code formatted with `cargo fmt`
- ✅ Zero new clippy warnings

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Performance improvement
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] All existing tests pass
- [x] Added new tests for optimization
- [x] Code formatted (`cargo fmt`)
- [x] No new clippy warnings
- [x] Added benchmarks
- [x] Documentation updated (inline comments)
- [x] No breaking changes

## Related Issues

Closes #44
Related: #5 (parent issue), #45 (Phase 3B), #46 (future language features)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>