### PR TITLE
Fix Dependabot auto-merge workflow to use PAT for approvals

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -97,7 +97,7 @@ jobs:
           gh pr review --approve "${{ github.event.pull_request.number }}" \
             --body "✓ Auto-approved: ${{ steps.metadata.outputs.update-type }} update passed all checks"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}
 
       - name: Enable auto-merge
         if: steps.update-type.outputs.auto-merge == 'true'
@@ -105,7 +105,7 @@ jobs:
           gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
           echo "✓ Auto-merge enabled for PR #${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}
 
       - name: Send notification
         if: steps.update-type.outputs.auto-merge == 'true'


### PR DESCRIPTION
## Summary

Fixes Dependabot auto-merge workflow to use Personal Access Token (PAT) for PR approvals instead of the default `GITHUB_TOKEN`.

Closes #67

## Problem

The Dependabot auto-merge workflow was failing to auto-approve and auto-merge PRs (including patch and minor version updates) because the default `GITHUB_TOKEN` cannot approve PRs due to GitHub Actions security restrictions.

This caused all Dependabot PRs to require manual review, even though the workflow was configured to auto-merge patch and minor version updates during business hours.

## Solution

Updated the workflow to use `DEPENDABOT_PAT` (Personal Access Token with `repo` scope) instead of `GITHUB_TOKEN` for both:

1. **Auto-approve step** (line 100): Approving the PR with a comment
2. **Enable auto-merge step** (line 108): Enabling auto-merge on the PR

## Changes

- `.github/workflows/dependabot-auto-merge.yml`:
  - Line 100: Changed `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` → `GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}`
  - Line 108: Changed `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` → `GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}`

## Expected Behavior After Fix

✅ **Patch updates** (1.2.3 → 1.2.4): Auto-approve and auto-merge during business hours once CI passes
✅ **Minor updates** (1.2.0 → 1.3.0): Auto-approve and auto-merge during business hours once CI passes
⚠️ **Major updates** (1.0.0 → 2.0.0): Still require manual review (as designed)

## Testing

- [x] All existing tests pass (148 tests)
- [x] Pre-commit checks pass (formatting, clippy, tests)
- [ ] Workflow will be tested on next Dependabot PR

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)