### PR TITLE
Fix WASM build by excluding tokio networking features

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM module
-        run: wasm-pack build --target web --out-dir pkg
+        run: wasm-pack build --target web --out-dir pkg --no-default-features --features wasm
 
       - name: Copy WASM files to docs
         run: |

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -3,7 +3,7 @@
 //! This module provides a JavaScript-friendly API for using JCL in the browser.
 
 use crate::ast::Module;
-use crate::{docgen, formatter, linter, parser};
+use crate::{docgen, formatter, linter};
 use wasm_bindgen::prelude::*;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.


### PR DESCRIPTION
## Summary

Fixes the WASM build failure by excluding tokio's networking features that are incompatible with wasm32.

Related to #69

## Problem

The initial fix in PR #70 added WASM build steps to the GitHub Pages workflow, but the build failed with this error:

```
error: This wasm target is unsupported by mio. If using Tokio, disable the net feature.
```

**Root Cause**: The default feature set includes the `cli` feature, which depends on `tokio` with `features = ["full"]`. This includes networking via `mio`, which doesn't support wasm32.

## Solution

Updated the WASM build command to use:
```bash
wasm-pack build --target web --out-dir pkg --no-default-features --features wasm
```

This:
1. **Excludes default features** (which include CLI and tokio)
2. **Enables only wasm features** (console_error_panic_hook, wee_alloc, uuid)
3. **Maintains all playground functionality** (parse, format, lint, docs)

Also removed an unused `parser` import from `wasm.rs` that was generating a warning.

## Changes

### `.github/workflows/pages.yml`
- Updated WASM build command to exclude tokio

### `src/bindings/wasm.rs`
- Removed unused `parser` import

## Testing

✅ **Local build test**:
```bash
$ wasm-pack build --target web --out-dir pkg --no-default-features --features wasm
[INFO]: ✨   Done in 1m 08s
[INFO]: 📦   Your wasm pkg is ready to publish
```

✅ **Zero warnings** in WASM build
✅ **All 148 tests pass**
✅ **Pre-commit checks pass** (format, clippy, tests)

## Expected Behavior After Merge

Once merged and the workflow runs:
- ✅ WASM build will complete successfully
- ✅ Playground will load at https://hemmer-io.github.io/jcl/guides/playground.html
- ✅ Parse, Format, Lint, and Docs features will work in the browser
- ✅ Status bar will show "JCL v1.0.0 ready" in green

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Local WASM build tested and successful
- [x] All existing tests pass (148 tests)
- [x] Pre-commit checks pass (formatting, clippy, tests)
- [x] Zero warnings in WASM build
- [x] No new compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)