### PR TITLE
Run test-build-packages workflow on PR merge to main

### DIFF
--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -6,8 +6,11 @@ name: Test Build Packages
 
 on:
   workflow_dispatch:  # Manual trigger
+  push:
+    branches:
+      - main  # Run when PRs are merged to main
   schedule:
-    # Run weekly on Monday at 9 AM UTC
+    # Run weekly on Monday at 9 AM UTC as backup
     - cron: '0 9 * * 1'
 
 jobs:


### PR DESCRIPTION
## Summary

Updates the test-build-packages workflow to run automatically when PRs are merged to main, providing immediate feedback on package build status.

Closes #74

## Problem

The workflow currently only runs:
- Manually via workflow_dispatch
- Weekly on schedule

This means build issues might not be discovered until the weekly run or manual trigger, delaying feedback after dependency updates or code changes.

## Solution

Add `push` trigger for the `main` branch:

```yaml
on:
  workflow_dispatch:  # Manual trigger (kept)
  push:
    branches:
      - main  # NEW: Run when PRs merge
  schedule:
    - cron: '0 9 * * 1'  # Weekly backup (kept)
```

## Changes

- Added `push: branches: [main]` to workflow triggers
- Kept manual trigger (workflow_dispatch)
- Kept weekly schedule as backup
- Updated comment to clarify schedule is a backup

## Benefits

✅ **Immediate feedback** - Build validation right after merge
✅ **Catch issues early** - Especially after Dependabot merges
✅ **Better CI/CD** - Validates packages before releases
✅ **Multiple triggers** - Still works manually and on schedule

## Expected Behavior After Merge

When this PR merges to main:
1. ✅ The workflow will run automatically (testing itself!)
2. ✅ All four builds (Cargo, PyPI, RubyGems, npm) will execute
3. ✅ Future PR merges will also trigger the workflow
4. ✅ Manual trigger and weekly schedule still work

## Type of Change

- [x] Bug fix (workflow improvement)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Workflow trigger updated
- [x] Manual trigger preserved
- [x] Weekly schedule preserved
- [x] Comment updated for clarity
- [x] No functional changes to build jobs

## Testing

This change will be validated when merged - the workflow should run automatically and all builds should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)