### PR TITLE
Update Ruby gem version to 1.1.0

### DIFF
--- a/bindings/ruby/jcl.gemspec
+++ b/bindings/ruby/jcl.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "jcl"
-  spec.version       = "1.0.0"
+  spec.version       = "1.1.0"
   spec.authors       = ["Hemmer IO"]
   spec.email         = ["info@hemmer.io"]
 


### PR DESCRIPTION
## Description

Fixes #81

This PR updates the Ruby gem version from `1.0.0` to `1.1.0` in `bindings/ruby/jcl.gemspec`, which was missed during the v1.1.0 release in PR #79.

## Problem

All package versions were correctly updated to 1.1.0 in the release PR:
- ✅ Root Cargo.toml 
- ✅ Python (pyproject.toml)
- ✅ Node.js (package.json) 
- ✅ Java (Cargo.toml)
- ✅ Ruby Cargo.toml

But the Ruby gemspec was left at 1.0.0 ❌

## Changes

- Updated `spec.version` in `bindings/ruby/jcl.gemspec` from `"1.0.0"` to `"1.1.0"`

## Testing

- [x] All existing tests pass
- [x] Pre-commit checks pass
- [x] No code changes, only version metadata

## Type of Change

- [x] Bug fix (version mismatch)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] All tests pass
- [x] No new warnings
- [x] Updated version metadata only