### PR TITLE
Fix YAML syntax error in auto-tag-release workflow

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   auto-tag:
     name: Auto-tag release when PR merges
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'type: release')
+    if: "github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'type: release')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -60,11 +60,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const version = '${{ steps.get_version.outputs.version }}';
             github.rest.issues.createComment({
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✅ Release tag \`v${{ steps.get_version.outputs.version }}\` created automatically.\n\n🚀 [Release workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/release.yml) is now building and publishing packages.`
+              body: `✅ Release tag \`v${version}\` created automatically.\n\n🚀 [Release workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/release.yml) is now building and publishing packages.`
             })
 
       - name: Tag already exists


### PR DESCRIPTION
## Description

Fixes #80

This PR fixes a YAML syntax error in the `auto-tag-release` workflow that caused it to fail when PR #79 was merged.

## Problem

The workflow failed with:
```
yaml.scanner.ScannerError: mapping values are not allowed here
  in ".github/workflows/auto-tag-release.yml", line 15, column 108
```

The YAML parser was interpreting the unquoted colon in `'type: release'` as a mapping key separator.

## Changes

1. **Quote `if` condition** - Wrap the entire conditional expression in quotes to prevent YAML from treating the colon as a mapping separator

   **Before**:
   ```yaml
   if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'type: release')
   ```

   **After**:
   ```yaml
   if: "github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'type: release')"
   ```

2. **Fix JavaScript template syntax** - Extract version to a const variable to avoid conflicts between GitHub Actions template syntax and JavaScript template literals

   **Before**:
   ```javascript
   body: `✅ Release tag \`v${{ steps.get_version.outputs.version }}\` created automatically.`
   ```

   **After**:
   ```javascript
   const version = '${{ steps.get_version.outputs.version }}';
   body: `✅ Release tag \`v${version}\` created automatically.`
   ```

## Testing

- [x] YAML syntax validated with Python parser
- [x] All existing tests pass
- [x] Pre-commit checks pass
- [x] No clippy warnings

## Type of Change

- [x] Bug fix (workflow syntax error)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] All tests pass
- [x] No new warnings
- [x] YAML syntax validated