### PR TITLE
Update documentation URLs to use jcl.hemmer.io custom domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -950,7 +950,7 @@ JCL used to be infrastructure-focused but is now **general-purpose**. The follow
 - Ready for publication
 
 **Resources**:
-- Full docs: https://turner-hemmer.github.io/jcl/
+- Full docs: https://jcl.hemmer.io/
 - Language spec: `docs/reference/language-spec.md`
 - Function reference: `docs/reference/functions.md`
 - Contributing: `CONTRIBUTING.md`

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ jcl-migrate config.json --from json
 
 ### Library Bindings (Recommended)
 
-- **Python**: `pip install jcl-lang` - [Docs](https://hemmer-io.github.io/jcl/bindings/python)
-- **Node.js**: `npm install @hemmer-io/jcl` - [Docs](https://hemmer-io.github.io/jcl/bindings/nodejs)
-- **Ruby**: `gem install jcl` - [Docs](https://hemmer-io.github.io/jcl/bindings/ruby)
-- **Go**: cgo bindings for Go projects - [Docs](https://hemmer-io.github.io/jcl/bindings/go)
-- **Java**: JNI bindings for Java applications - [Docs](https://hemmer-io.github.io/jcl/bindings/java)
+- **Python**: `pip install jcl-lang` - [Docs](https://jcl.hemmer.io/bindings/python)
+- **Node.js**: `npm install @hemmer-io/jcl` - [Docs](https://jcl.hemmer.io/bindings/nodejs)
+- **Ruby**: `gem install jcl` - [Docs](https://jcl.hemmer.io/bindings/ruby)
+- **Go**: cgo bindings for Go projects - [Docs](https://jcl.hemmer.io/bindings/go)
+- **Java**: JNI bindings for Java applications - [Docs](https://jcl.hemmer.io/bindings/java)
 
 ### CLI Tool
 
@@ -127,11 +127,11 @@ cargo build --release
 
 ## Documentation
 
-- **[Getting Started Guide](https://hemmer-io.github.io/jcl/getting-started/)** - Learn JCL basics
-- **[Language Specification](https://hemmer-io.github.io/jcl/reference/language-spec)** - Complete syntax reference
-- **[Built-in Functions](https://hemmer-io.github.io/jcl/reference/functions)** - 70+ functions documented
-- **[CLI Tools](https://hemmer-io.github.io/jcl/reference/cli-tools)** - Command-line utilities
-- **[Comparison Guide](https://hemmer-io.github.io/jcl/guides/comparison)** - JCL vs other formats
+- **[Getting Started Guide](https://jcl.hemmer.io/getting-started/)** - Learn JCL basics
+- **[Language Specification](https://jcl.hemmer.io/reference/language-spec)** - Complete syntax reference
+- **[Built-in Functions](https://jcl.hemmer.io/reference/functions)** - 70+ functions documented
+- **[CLI Tools](https://jcl.hemmer.io/reference/cli-tools)** - Command-line utilities
+- **[Comparison Guide](https://jcl.hemmer.io/guides/comparison)** - JCL vs other formats
 
 ## Key Features
 
@@ -252,7 +252,7 @@ BASH
 
 ### Additional Bindings
 
-- **WebAssembly**: Browser and serverless support - [Playground](https://hemmer-io.github.io/jcl/guides/playground)
+- **WebAssembly**: Browser and serverless support - [Playground](https://jcl.hemmer.io/guides/playground)
 - **C FFI**: Embed in any language with C interop
 - **Rust**: Native `cargo install jcl` for maximum performance
 
@@ -343,7 +343,7 @@ at your option.
 
 ## Community
 
-- **Documentation**: [https://hemmer-io.github.io/jcl/](https://hemmer-io.github.io/jcl/)
+- **Documentation**: [https://jcl.hemmer.io/](https://jcl.hemmer.io/)
 - **Repository**: [https://github.com/hemmer-io/jcl](https://github.com/hemmer-io/jcl)
 - **Issues**: [https://github.com/hemmer-io/jcl/issues](https://github.com/hemmer-io/jcl/issues)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,8 +2,8 @@
 
 title: JCL
 description: Jack-of-All Configuration Language - A powerful, flexible configuration language
-baseurl: "/jcl"
-url: "https://hemmer-io.github.io"
+baseurl: ""
+url: "https://jcl.hemmer.io"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
## Description

Updates all documentation URLs from `hemmer-io.github.io/jcl` and `turner-hemmer.github.io/jcl` to the new custom domain `jcl.hemmer.io` with HTTPS.

Closes #98

## Type of Change

- [x] Documentation update
- [x] Configuration change

## Changes Made

1. **docs/_config.yml**:
   - Updated `url` from `https://hemmer-io.github.io` to `https://jcl.hemmer.io`
   - Cleared `baseurl` (custom domains don't need the `/jcl` path)

2. **README.md**:
   - Updated 12 documentation links to use new domain
   - Links affected: bindings docs, getting started, language spec, functions, CLI tools, comparison guide, playground, main docs link

3. **CLAUDE.md**:
   - Updated docs link from old `turner-hemmer.github.io/jcl` to `jcl.hemmer.io`

## Testing

- [x] All existing tests pass (205 tests)
- [x] Code formatted with `cargo fmt`
- [x] No clippy errors
- [x] Verified no old domain references remain (except localhost examples)
- [x] All HTTPS links verified

## Notes

- Local development examples (`http://localhost:*`) are intentionally preserved as HTTP
- All external documentation links now use HTTPS
- Custom domain eliminates need for `/jcl` baseurl path

## Checklist

- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy`
- [x] Updated documentation
- [x] No new warnings
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)