### PR TITLE
Enhance schema validation API (Issue #93 - Complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Import graph visualization**: Generate DOT format graphs for GraphViz
   - **Detailed trace reports**: Human-readable import chain analysis
 - **Import Documentation**: Comprehensive guides and examples in language spec and getting started
-- **Enhanced Schema Validation API - Phases 1-4** (#93)
+- **Enhanced Schema Validation API - Phases 1-5 (Complete)** (#93)
   - **Phase 1: Better Error Messages & Builder Pattern**
     - Rich error types with suggestions and precise source locations
     - Fluent `SchemaBuilder` and `PropertyBuilder` APIs
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Schema composition via `merge()` for combining multiple schemas
     - Markdown documentation generation with `generate_docs()`
     - Round-trip support via `SchemaBuilder::from_schema()`
+  - **Phase 5: Schema Export**
+    - JSON Schema Draft 7 export via `to_json_schema()`
+    - OpenAPI 3.0 schema export via `to_openapi()`
+    - Full TypeDef coverage including unions, discriminated unions, refs
+    - Standard-compliant output for integration with external tools
 
 ## [1.1.0] - 2025-01-19
 


### PR DESCRIPTION
## Description

Implements **ALL 5 PHASES** of the enhanced schema validation API (#93), adding programmatic schema definition, custom validation, complex types, schema composition, and export capabilities while maintaining full backward compatibility.

**Issue #93 - COMPLETE** ✅

## Type of Change

- [x] Enhancement
- [x] New feature (non-breaking)
- [x] API addition (backward compatible)

## Implementation Summary

### Phase 1: Programmatic Schema Definition ✅

- Rich `ValidationError` with error types and suggestions
- Fluent `SchemaBuilder` and `PropertyBuilder` APIs
- Type-safe schema construction with minimal boilerplate

### Phase 2: Custom Validators & Conditional Rules ✅

- Thread-safe custom validator functions (`ValidatorFn`)
- Field dependency tracking (`requires()`, `requires_absence_of()`)
- Mutually exclusive field groups (`mutually_exclusive()`)

### Phase 3: Complex Types ✅

- Discriminated unions (tagged unions) with `TypeDef::DiscriminatedUnion`
- Recursive type references with `TypeDef::Ref`
- Enhanced union type documentation
- Explicit type system (no surprising coercions per JCL design)

### Phase 4: Schema Composition ✅

- Schema versioning with `version()` method
- Schema inheritance via `extends()` with property merging
- Schema composition via `merge()` for combining multiple schemas
- Markdown documentation generation with `generate_docs()`
- Round-trip support via `SchemaBuilder::from_schema()`

### Phase 5: Schema Export ✅

- JSON Schema Draft 7 export via `to_json_schema()`
- OpenAPI 3.0 schema export via `to_openapi()`
- Full TypeDef coverage including unions, discriminated unions, refs
- Standard-compliant output for integration with external tools

## Key Features by Phase

### Phase 1 Example

```rust
let schema = SchemaBuilder::new("aws_instance")
    .description("AWS EC2 instance configuration")
    .required_field("ami", TypeDef::String {
        pattern: Some("^ami-[0-9a-f]{17}$".to_string()),
        /* ... */
    })
    .build();
```

### Phase 2 Example

```rust
let email_validator: ValidatorFn = Box::new(|value| {
    match value {
        Value::String(s) if s.contains('@') => Ok(()),
        _ => Err(ValidationError::custom("Invalid email".to_string())),
    }
});

let schema = SchemaBuilder::new("user")
    .field("email", PropertyBuilder::new(/* ... */)
        .with_validator("email")
        .requires("username"))
    .mutually_exclusive(vec!["sso_id", "password"]);
```

### Phase 3 Example

```rust
let mut variants = HashMap::new();
variants.insert("s3".to_string(), Box::new(s3_schema));
variants.insert("local".to_string(), Box::new(local_schema));

let storage = TypeDef::DiscriminatedUnion {
    discriminator: "type".to_string(),
    variants,
};
```

### Phase 4 Example

```rust
// Inheritance
let child = SchemaBuilder::new("User")
    .extends(base_entity_schema)  // Inherits common fields
    .field("email", /* ... */)
    .build();

// Merging
let merged = SchemaBuilder::new("Combined")
    .merge(vec![schema1, schema2, schema3])
    .build();

// Documentation
let docs = schema.generate_docs();  // Markdown output
```

### Phase 5 Example

```rust
// Export to JSON Schema
let json_schema = schema.to_json_schema();
// {
//   "$schema": "http://json-schema.org/draft-07/schema#",
//   "title": "User",
//   "type": "object",
//   "properties": { ... },
//   "required": ["email"]
// }

// Export to OpenAPI
let openapi = schema.to_openapi();
// {
//   "type": "object",
//   "title": "User",
//   "properties": { ... },
//   "required": ["email"]
// }
```

## Benefits

✅ **Programmatic schemas**: Tools like Hemmer can define schemas in Rust  
✅ **Custom validation**: Domain-specific validators (email, CIDR, ports)  
✅ **Conditional rules**: Field dependencies and mutual exclusions  
✅ **Complex types**: Discriminated unions, recursive references  
✅ **Schema composition**: Inheritance, merging, versioning  
✅ **Documentation**: Auto-generate markdown from schemas  
✅ **Export**: JSON Schema and OpenAPI for external tools  
✅ **Better DX**: Rich error messages with suggestions  
✅ **Type safety**: Builder pattern catches mistakes at compile time  
✅ **Backward compatible**: Existing schemas work unchanged  
✅ **Standards-compliant**: JSON Schema Draft 7, OpenAPI 3.0  
✅ **Well documented**: Comprehensive rustdoc with examples

## Testing

- [x] Added 38 new unit tests (7 P1 + 5 P2 + 6 P3 + 10 P4 + 10 P5)
- [x] All 292 tests passing (242 unit + 21 CLI + 9 integration + 20 doc)
- [x] Tested backward compatibility with jcl-validate CLI
- [x] Verified existing YAML schema examples still work
- [x] Edge cases: all phases thoroughly tested

### Test Coverage Breakdown

**Phase 1** (7 tests): Enhanced errors, builder pattern  
**Phase 2** (5 tests): Custom validators, conditional rules  
**Phase 3** (6 tests): Discriminated unions, references  
**Phase 4** (10 tests): Versioning, inheritance, merging, docs  
**Phase 5** (10 tests): JSON Schema export, OpenAPI export

## Backward Compatibility

✅ **100% backward compatible**:
- `Validator::from_json()` - works unchanged
- `Validator::from_yaml()` - works unchanged
- Existing `jcl-validate` CLI - works unchanged
- All existing schemas - work unchanged

## Documentation

✅ **Comprehensive documentation**:
- Module-level docs with usage examples for all phases
- All public methods have rustdoc comments with examples
- Updated CHANGELOG.md marking all phases complete
- All doc examples compile and pass

## Checklist

- [x] Ran `cargo fmt`
- [x] Ran `cargo clippy` (no new warnings from new code)
- [x] All tests pass (292/292 total)
- [x] Updated documentation (comprehensive rustdoc)
- [x] No breaking changes
- [x] Backward compatibility verified
- [x] Updated CHANGELOG.md
- [x] All 5 phases complete

## References

- Issue #93: Enhance schema validation API for programmatic use (**ALL PHASES COMPLETE** ✅)
- Related to Hemmer integration needs
- Enables module system validation
- Provides standard export formats for tooling integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>