### PR TITLE
Fix Dependabot auto-merge workflow to use DEPENDABOT_PAT consistently

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -145,7 +145,7 @@ jobs:
 
           Dependencies updated: ${{ steps.metadata.outputs.dependency-names }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}
 
       - name: Check if outside business hours
         if: needs.check-business-hours.outputs.is-business-hours == 'false'
@@ -165,4 +165,4 @@ jobs:
 
           You can manually merge this PR at any time if needed." || true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}


### PR DESCRIPTION
## Description

Fixes the Dependabot auto-merge workflow by ensuring all `gh` CLI operations consistently use the `DEPENDABOT_PAT` secret instead of mixing `DEPENDABOT_PAT` and `GITHUB_TOKEN`.

## Problem

The workflow was inconsistently using two different tokens:
- Lines 100, 108: Used `secrets.DEPENDABOT_PAT` ✅
- Lines 148, 168: Used `secrets.GITHUB_TOKEN` ❌

This inconsistency could cause authentication issues or permission problems when the workflow tries to:
- Comment on PRs for major version updates
- Comment on PRs created outside business hours

## Changes

Updated lines 148 and 168 to use `secrets.DEPENDABOT_PAT` for consistency with the rest of the workflow.

All four `gh` CLI operations now use the same token:
1. `gh pr review` (line 100)
2. `gh pr merge` (line 108)  
3. `gh pr comment` for major versions (line 148)
4. `gh pr comment` for business hours (line 168)

## Testing

- ✅ Pre-commit checks passed (formatting, clippy, all tests)
- ✅ No changes to workflow logic, only token reference
- ✅ Workflow file syntax validated

## Related

- Addresses issues with PR #115 (Dependabot pest update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)