### PR TITLE
Fix Python bindings to handle Value::Stream variant

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -127,6 +127,10 @@ fn value_to_python(py: Python, value: &Value) -> PyResult<PyObject> {
             // Functions can't be directly converted to Python
             Ok("<function>".to_object(py))
         }
+        Value::Stream(id) => {
+            // Streams can't be directly converted to Python
+            Ok(format!("<stream:{}>", id).to_object(py))
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fixes the Python bindings compilation error introduced by the streaming API PR (#116).

## Problem

The streaming API PR added a new `Value::Stream` variant to the AST, but the Python bindings didn't handle it in the `value_to_python()` function:

```
error[E0004]: non-exhaustive patterns: `&Value::Stream(_)` not covered
  --> bindings/python/src/lib.rs:106:11
```

This caused the "Test PyPI (Python) Build" workflow to fail.

## Changes

Added missing match arm for `Value::Stream` in `value_to_python()` function (bindings/python/src/lib.rs:130-133):

```rust
Value::Stream(id) => {
    // Streams can't be directly converted to Python
    Ok(format!("<stream:{}>", id).to_object(py))
}
```

This follows the same pattern as `Value::Function` - non-serializable types are converted to string representations.

## Testing

- ✅ Python bindings compile successfully: `cargo check` in bindings/python
- ✅ All pre-commit checks passed (formatting, clippy, all 327 tests)
- ✅ No behavioral changes - streams still can't be directly converted to Python objects

## Related

- Fixes Python package build failure from streaming API PR #116
- Part of the fixes needed after merging the streaming API

🤖 Generated with [Claude Code](https://claude.com/claude-code)