### PR TITLE
Fix Dependabot auto-merge workflow to allow skipped checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -89,7 +89,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
           running-workflow-name: 'Auto-Merge Dependabot PR'
-          allowed-conclusions: success
+          allowed-conclusions: success,skipped
 
       - name: Auto-approve PR
         if: steps.update-type.outputs.auto-merge == 'true'


### PR DESCRIPTION
## Description

Fixes the Dependabot auto-merge workflow which was failing even though all CI checks passed.

## Problem

The workflow was failing with this error:
```
The conclusion of one or more checks were not allowed. Allowed conclusions are: success.
```

The "Wait for CI checks" step was configured to only accept `success` as an allowed conclusion:
```yaml
allowed-conclusions: success
```

However, some workflows like "Auto-tag release when PR merges" have a status of `skipped` on Dependabot PRs, causing the workflow to fail even though all actual tests passed.

## Solution

Changed `allowed-conclusions` to accept both `success` and `skipped`:
```yaml
allowed-conclusions: success,skipped
```

This allows the workflow to proceed when some checks are skipped, which is normal behavior for certain workflows that don't run on Dependabot PRs.

## Testing

- ✅ Pre-commit checks passed (formatting, clippy, all 327 tests)
- Workflow will be tested on the next Dependabot PR

## Related

- Fixes #120
- Follows up on PR #118 (token configuration fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)