### PR TITLE
Add cross-compilation support for all major platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,49 @@ env:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - os: ubuntu-latest
+          # Native builds (with tests)
+          - name: Linux x86_64
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+            cross: false
+            test: true
+
+          - name: macOS ARM64 (Apple Silicon)
+            os: macos-latest
             target: aarch64-apple-darwin
-          - os: windows-latest
+            cross: false
+            test: true
+
+          - name: macOS x86_64 (Intel)
+            os: macos-latest
+            target: x86_64-apple-darwin
+            cross: false
+            test: true  # Can test via Rosetta on ARM runners
+
+          - name: Windows x86_64
+            os: windows-latest
             target: x86_64-pc-windows-msvc
+            cross: false
+            test: true
+
+          # Cross-compiled builds (build only, no tests)
+          - name: Linux ARM64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
+            test: false
+
+          - name: Linux x86_64 MUSL (static)
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            cross: true
+            test: false
 
     steps:
       - name: Checkout code
@@ -31,8 +62,49 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }} --verbose
+      # Install cross for cross-compilation targets
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
+      # Native build
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+
+      # Cross-compiled build
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      # Run tests only on native builds
       - name: Run tests
-        run: cargo test --release --target ${{ matrix.target }} --verbose
+        if: matrix.test
+        run: cargo test --release --target ${{ matrix.target }}
+
+      # Upload build artifacts
+      - name: Upload binary (Unix)
+        if: matrix.os != 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jcl-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/jcl-cli
+            target/${{ matrix.target }}/release/jcl-fmt
+            target/${{ matrix.target }}/release/jcl-lsp
+            target/${{ matrix.target }}/release/jcl-validate
+            target/${{ matrix.target }}/release/jcl-migrate
+          if-no-files-found: error
+
+      - name: Upload binary (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jcl-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/jcl-cli.exe
+            target/${{ matrix.target }}/release/jcl-fmt.exe
+            target/${{ matrix.target }}/release/jcl-lsp.exe
+            target/${{ matrix.target }}/release/jcl-validate.exe
+            target/${{ matrix.target }}/release/jcl-migrate.exe
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,22 +40,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Native builds
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             archive_ext: tar.gz
             platform: linux-amd64
+            cross: false
           - os: macos-latest
             target: x86_64-apple-darwin
             archive_ext: tar.gz
             platform: macos-amd64
+            cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
             platform: macos-arm64
+            cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             archive_ext: zip
             platform: windows-amd64
+            cross: false
+          # Cross-compiled builds
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            archive_ext: tar.gz
+            platform: linux-arm64
+            cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            archive_ext: tar.gz
+            platform: linux-amd64-musl
+            cross: true
 
     steps:
       - name: Checkout code
@@ -66,11 +82,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build release binaries
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build release binaries (native)
+        if: ${{ !matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip binaries (Linux and macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Build release binaries (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Strip binaries (Linux and macOS - native only)
+        if: matrix.os != 'windows-latest' && !matrix.cross
         run: |
           strip target/${{ matrix.target }}/release/jcl-cli || true
           strip target/${{ matrix.target }}/release/jcl-lsp || true


### PR DESCRIPTION
## Summary

Adds cross-compilation support to build pre-built binaries for all major platforms, making JCL easily distributable without requiring users to build from source.

Closes #117

## Changes

### Build Workflow (`build.yml`)

Extended the build matrix from 3 to 6 targets:

**Native builds (with tests):**
| Platform | Target | Runner |
|----------|--------|--------|
| Linux x86_64 | `x86_64-unknown-linux-gnu` | ubuntu-latest |
| macOS ARM64 | `aarch64-apple-darwin` | macos-latest |
| macOS x86_64 | `x86_64-apple-darwin` | macos-latest |
| Windows x86_64 | `x86_64-pc-windows-msvc` | windows-latest |

**Cross-compiled builds (build only, no tests):**
| Platform | Target | Runner | Use Case |
|----------|--------|--------|----------|
| Linux ARM64 | `aarch64-unknown-linux-gnu` | ubuntu-latest | Raspberry Pi, AWS Graviton |
| Linux MUSL | `x86_64-unknown-linux-musl` | ubuntu-latest | Alpine, Docker, static linking |

Other changes:
- Added `cross-rs/cross` installation for cross-compilation
- Conditional test execution (native targets only)
- Upload build artifacts for all targets

### Release Workflow (`release.yml`)

- Added ARM Linux and MUSL targets to release builds
- Conditional `cross` installation and build steps
- Skip `strip` for cross-compiled binaries (wrong host architecture)

## Benefits

- **Users can install without building** - Download pre-built binaries
- **ARM Linux support** - Raspberry Pi, AWS Graviton, other ARM64 devices
- **Intel Mac support** - Still ~40% of Mac market
- **Container-friendly** - MUSL builds for Alpine/Docker with static linking
- **Automated releases** - All 6 targets built on every tagged release

## Testing

- [ ] All 6 build targets complete successfully in CI
- [ ] Native targets run full test suite
- [ ] Cross-compiled targets build without errors
- [ ] Artifacts uploaded correctly

## Platform Coverage

After this PR, JCL will have pre-built binaries for:

```
jcl-linux-amd64        # Linux x86_64 (glibc)
jcl-linux-amd64-musl   # Linux x86_64 (static/Alpine)
jcl-linux-arm64        # Linux ARM64 (Raspberry Pi, Graviton)
jcl-macos-amd64        # macOS Intel
jcl-macos-arm64        # macOS Apple Silicon
jcl-windows-amd64      # Windows x86_64
```

This covers ~95% of target platforms users would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)